### PR TITLE
Added 2to3 support to setup for compatability with Python 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 from setuptools import setup, find_packages
+import sys
 
 version = '2.1.5'
+
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
 
 setup(
     name='textile',
@@ -24,4 +29,5 @@ setup(
     tests_require = ['nose'],
     include_package_data=True,
     zip_safe=False,
+    **extra
 )


### PR DESCRIPTION
This change simply implements the 2to3 hook available to convert the package to Python 3.x during the execution of setup.py.  No further changes seem necessary to support 3.x.
