### PR TITLE
Fix @@ and <notextile></notextile> for table edge cases

### DIFF
--- a/textile/functions.py
+++ b/textile/functions.py
@@ -951,7 +951,7 @@ class Textile(object):
         return ''.join([before, '<pre>', self.shelve(text), '</pre>', after])
 
     def doSpecial(self, text, start, end, method):
-        pattern = re.compile(r'(^|\s|[\[({>])%s(.*?)%s(\s|$|[\])}])?'
+        pattern = re.compile(r'(^|\s|[\[({>|])%s(.*?)%s($|[\])}])?'
                              % (re.escape(start), re.escape(end)), re.M | re.S)
         return pattern.sub(method, text)
 

--- a/textile/tests/__init__.py
+++ b/textile/tests/__init__.py
@@ -434,3 +434,9 @@ class Tests():
         result = '\t<p><img src="http://www.google.com/intl/en_ALL/images/srpr/logo1w.png" alt="" width="275" height="95" /></p>'
         expect = textile.Textile(get_sizes=True).textile(test)
         eq_(result, expect)
+
+    def testAtSignAndNotextileInTable(self):
+        test = "|@<A1>@|@<A2>@ @<A3>@|\n|<notextile>*B1*</notextile>|<notextile>*B2*</notextile> <notextile>*B3*</notextile>|"
+        result = "\t<table>\n\t\t<tr>\n\t\t\t<td><code>&#60;A1&#62;</code></td>\n\t\t\t<td><code>&#60;A2&#62;</code> <code>&#60;A3&#62;</code></td>\n\t\t</tr>\n\t\t<tr>\n\t\t\t<td>*B1*</td>\n\t\t\t<td>*B2* *B3*</td>\n\t\t</tr>\n\t</table>"
+        expect = textile.textile(test)
+        eq_(result, expect)


### PR DESCRIPTION
Changed regex in textile.doSpecial() to:
1. Allow vertical pipe (|) to anchor beginning of match.  Otherwise, angle bracket match option may cause
`<code></code>` span to cross table cell boundary for sequential cells containing @<…>@.
2. Leave trailing whitespace.  Trailing whitespace may not be symmetric with leading whitespace, so
shouldn't be removed.  Removes necessity of including multiple spaces between (admitted unlikely)
consecutive `<notextile></notextile>` instances.

Added test: textile.tests:Tests.testAtSignAndNotextileInTable
