### PR TITLE
Support Pillow

### DIFF
--- a/textile/tests/__init__.py
+++ b/textile/tests/__init__.py
@@ -426,7 +426,7 @@ class Tests():
 
     def testImageSize(self):
         try:
-            import ImageFile
+            from PIL import ImageFile
         except ImportError:
             raise SkipTest()
 

--- a/textile/tools/imagesize.py
+++ b/textile/tools/imagesize.py
@@ -14,7 +14,7 @@ def getimagesize(url):
     """
 
     try:
-        import ImageFile
+        from PIL import ImageFile
         import urllib2
     except ImportError:
         return ''
@@ -36,6 +36,6 @@ def getimagesize(url):
 def setup_module(module):
     from nose.plugins.skip import SkipTest
     try:
-        import ImageFile
+        from PIL import ImageFile
     except ImportError:
         raise SkipTest()


### PR DESCRIPTION
From https://bugzilla.redhat.com/show_bug.cgi?id=896295:

Fedora 19 is going to stop shipping python-imaging (PIL) and start shipping python-pillow instead.  Rationale can be found on the [feature page](https://fedoraproject.org/wiki/Features/Pillow).

pillow should be compatible with PIL at the code level but the import statement changes slightly.

PIL supports both of these:

```
import Image
```

and

```
from PIL import Image
```

Pillow only supports the latter form.
